### PR TITLE
Add missing +libmpsse

### DIFF
--- a/lora-gateway/Makefile
+++ b/lora-gateway/Makefile
@@ -24,7 +24,7 @@ define Package/lora-gateway
 $(call Package/lora-gateway/Default)
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+libuci +libftdi +libsqlite3
+  DEPENDS:=+libmpsse +libuci +libftdi +libsqlite3
 endef
 
 define Package/lora-gateway/description


### PR DESCRIPTION
Add missing +libmpsse to fix error mpsse.h not found on OpenWrt compile.